### PR TITLE
feat: add GitHub Actions workflows for building and releasing multi-a…

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,58 @@
+name: Build and Push Multi-Arch Images
+
+on:
+  push:
+    branches: [ main, master ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main, master ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/chartmuseum2oci
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push multi-arch image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./chartmuseum2oci
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: |
+          TARGETOS=linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release Multi-Arch Images
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/chartmuseum2oci
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest
+
+    - name: Build and push multi-arch image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./chartmuseum2oci
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Release ${{ github.ref_name }}
+        tag_name: ${{ github.ref_name }}
+        generate_release_notes: true
+        draft: false
+        prerelease: false

--- a/chartmuseum2oci/Dockerfile
+++ b/chartmuseum2oci/Dockerfile
@@ -2,14 +2,21 @@ FROM golang:1.20 AS builder
 
 WORKDIR /root/src
 
+# Set build arguments for multi-arch support
+ARG TARGETOS=linux
+ARG TARGETARCH
+
 ENV CGO_ENABLED=0 \
     GO111MODULE=on \
-    GOOS="linux"
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH}
 
 COPY go.mod go.sum ./
 COPY main.go ./
 
+# Build the binary with proper architecture targeting
 RUN go build -a \
+    -ldflags="-w -s" \
     -o /go/bin/chartmuseum2oci \
     main.go
 
@@ -31,6 +38,7 @@ RUN if [ -z "$TARGETARCH" ]; then \
         esac; \
     fi
 
+# Download and install Helm for the target architecture
 RUN wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz -O - \
     | tar -xzO linux-${TARGETARCH}/helm > /bin/helm && \
     chmod +x /bin/helm


### PR DESCRIPTION
…rch images.

This commit introduces two new workflows:
1. `build-and-push.yml` for building and pushing multi-architecture Docker images on push and pull request events.
2. `release.yml` for creating GitHub releases and pushing multi-arch images when tags are pushed.

Additionally, the Dockerfile is updated to support multi-architecture builds by using build arguments for target OS and architecture.